### PR TITLE
Remove dist from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 coverage
-dist
 .DS_Store


### PR DESCRIPTION
Dist is not auto-generated in this package, so dist should not be in .gitignore